### PR TITLE
add title page and ToC

### DIFF
--- a/1890rules-en-translation.tex
+++ b/1890rules-en-translation.tex
@@ -14,6 +14,7 @@
 
 \title{1890}
 \setcounter{secnumdepth}{4}
+\setcounter{tocdepth}{2}
 \begin{document}
 
 \begin{titlepage}
@@ -29,7 +30,9 @@
 \end{titlepage}
 
 \pagenumbering{roman}
+\begin{multicols}{2}
 \tableofcontents
+\end{multicols}
 \pagebreak
 \pagenumbering{arabic}
 

--- a/1890rules-en-translation.tex
+++ b/1890rules-en-translation.tex
@@ -15,6 +15,24 @@
 \title{1890}
 \setcounter{secnumdepth}{4}
 \begin{document}
+
+\begin{titlepage}
+  \vspace*{\stretch{1.0}}
+  \begin{center}
+    \Huge\textbf{1890 Rules}\\
+    \vspace*{\stretch{0.1}}
+    \Large{The Railways of Kansai}\\
+    \vspace*{\stretch{0.5}}
+    \large\textit{Shin-ichi Takasaki}
+  \end{center}
+  \vspace*{\stretch{2.0}}
+\end{titlepage}
+
+\pagenumbering{roman}
+\tableofcontents
+\pagebreak
+\pagenumbering{arabic}
+
 \begin{CJK}{UTF8}{min}
 \begin{multicols}{2}
 \section*{Introduction}


### PR DESCRIPTION
The first push adds them, but the ToC is 6pp long.  I dropped one level of ToC to get it down to 3pp, but there was still too much wasted space.  Thus I ended up with two columns, which reduced it to 2pp.